### PR TITLE
Replace naiive tree-matching with compiled tree pattern matching

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ BAP_DEPS = \
 BAP_REPO := git+https://github.com/BinaryAnalysisPlatform/opam-repository\#testing
 
 all:
-	dune build
+	dune build --profile=release
 
 clean:
 	dune clean
@@ -24,7 +24,7 @@ uninstall:
 	dune uninstall
 
 test:
-	dune test
+	dune test --profile=release
 
 doc:
 	dune build @doc

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -34,6 +34,7 @@
   live_intf
   loops
   loops_intf
+  matcher
   patricia_tree
   patricia_tree_intf
   phi_values

--- a/src/lib/egraph/egraph.mli
+++ b/src/lib/egraph/egraph.mli
@@ -51,15 +51,11 @@ type 'a callback = subst -> 'a
 (** A rewrite rule. *)
 type rule
 
-(** A table of rules. *)
+(** The compiled rules. *)
 type rules
 
-(** Creates a table from a list of rules.
-
-    @raise Invalid_argument if there is a rule where the precondition is
-    a variable at the top-level.
-*)
-val create_table : rule list -> rules
+(** Compiles the rules. *)
+val compile : rule list -> rules
 
 (** [run fn tenv rules ?depth_limit ?match_limit] constructs an e-graph
     from a function [fn] and applies the [rules] eagerly to produce a

--- a/src/lib/egraph/egraph_node.ml
+++ b/src/lib/egraph/egraph_node.ml
@@ -43,6 +43,22 @@ let is_const = function
   | N (Osym _, []) -> true
   | N _ | U _ -> false
 
+let is_commutative = function
+  | Obinop b ->
+    begin match b with
+      | `add _
+      | `mul _
+      | `mulh _
+      | `umulh _
+      | `and_ _
+      | `or_ _
+      | `xor _
+      | `eq _
+      | `ne _ -> true
+      | _ -> false
+    end
+  | _ -> false
+
 let commute = function
   | N (Obinop b, [x; y]) ->
     begin match b with

--- a/src/lib/egraph/egraph_rule.ml
+++ b/src/lib/egraph/egraph_rule.ml
@@ -1,4 +1,5 @@
 open Egraph_common
+open Matcher
 
 type t = rule
 

--- a/src/lib/isel/isel_match.ml
+++ b/src/lib/isel/isel_match.ml
@@ -21,133 +21,87 @@ module Make(M : Machine_intf.S)(C : Context_intf.S) = struct
 
   let pp_node t = pp_node t Rv.pp
 
-  type pat =
-    | V1 of string
-    | P1 of P.op * pat list
-
-  let rec pp_pat ppf = function
-    | V1 x -> Format.fprintf ppf "?%s" x
-    | P1 (op, []) -> Format.fprintf ppf "%a" P.pp_op op
-    | P1 (op, ps) ->
-      let pp_sep ppf () = Format.fprintf ppf " " in
-      Format.fprintf ppf "(%a %a)"
-        P.pp_op op
-        (Format.pp_print_list ~pp_sep pp_pat)
-        ps
-
-  let rec to_untyped : type a b. (a, b) P.t -> pat = function
-    | P (op, ps) -> P1 (op, List.map ps ~f:to_untyped)
-    | V x -> V1 x
-
-  type tables = {
-    moves : (P.op, (pat * pat list * callback list) Vec.t) Hashtbl.t;
-    other : (P.op, (pat list * callback list) Vec.t) Hashtbl.t;
-  }
-
-  (* Reduce the search space by specializing the top-level pattern
-     for each rule's LHS. It stands to reason that we will have many
-     rules but only a handful of them will match with the current node
-     at any given time. *)
-  let build_tables (rules : rule list) =
-    let module Op = struct
-      type t = P.op [@@deriving compare, hash, sexp]
-    end in
-    let ts = {
-      moves = Hashtbl.create (module Op);
-      other = Hashtbl.create (module Op);
-    } in
-    let update t k a = match Hashtbl.find t k with
-      | Some s -> Vec.push s a
-      | None ->
-        let s = Vec.create () in
-        Vec.push s a;
-        Hashtbl.set t ~key:k ~data:s in
-    List.iter rules ~f:(fun (pre, post) ->
-        (* Skip rules that won't produce anything. *)
-        if not @@ List.is_empty post then
-          match to_untyped pre with
-          | P1 (Omove, [a; P1 (op, ps)]) ->
-            (* Specialize based on the operation for the move. *)
-            update ts.moves op (a, ps, post)
-          | P1 (op, ps) ->
-            (* All other cases should be less frequent in practice. *)
-            update ts.other op (ps, post)
-          | V1 _ -> assert false);
-    ts
-
   let rules = (I.rules :> rule list)
-  let tables = build_tables rules
 
-  let commutable = function
-    | P.Obinop b ->
-      begin match b with
-        | `add _
-        | `mul _
-        | `mulh _
-        | `umulh _
-        | `and_ _
-        | `or_ _
-        | `xor _
-        | `eq _
-        | `ne _ -> true
+  module Matcher = Matcher.Make(struct
+      type op = P.op [@@deriving compare, equal, hash, sexp]
+      type term = Rv.t node [@@deriving equal]
+      type id = Id.t [@@deriving equal]
+
+      let is_commutative = function
+        | P.Obinop b ->
+          begin match b with
+            | `add _
+            | `mul _
+            | `mulh _
+            | `umulh _
+            | `and_ _
+            | `or_ _
+            | `xor _
+            | `eq _
+            | `ne _ -> true
+            | _ -> false
+          end
         | _ -> false
-      end
-    | _ -> false
 
-  (* The actual tree-matching routine, which builds up a substitution
-     for the LHS of a rule, for consumption by the callbacks on the RHS. *)
-  let search t =
-    let subst env id x term = Map.update env x ~f:(function
-        | Some i when i.S.id = id ->
-          assert (S.equal_term Rv.equal i.tm term); i
-        | Some _ -> raise_notrace Mismatch
-        | None -> S.{id; tm = term}) in
-    let regvar env x r id k = match typeof t id with
-      | Some (#Type.basic as ty) ->
-        k @@ subst env id x @@ Regvar (r, ty)
-      | Some `v128 ->
-        k @@ subst env id x @@ Regvar_v r
-      | Some `flag ->
-        k @@ subst env id x @@ Regvar (r, wordb)
+      let term_op = function
+        | N (o, _) -> Some o
+        | Rv _ | Tbl _ | Callargs _ -> None
+
+      let term_args = function
+        | N (_, args) -> args
+        | Rv _ | Tbl _ | Callargs _ -> []
+
+      let pp_id = Id.pp
+      let pp_op = P.pp_op
+    end)
+
+  module VM = Matcher.VM
+  module Y = Matcher.Yield
+
+  let prog, vm =
+    let rec to_untyped : type a b. (a, b) P.t -> Matcher.pat = function
+      | P (op, ps) -> P (op, List.map ps ~f:to_untyped)
+      | V x -> V x in
+    let pats = List.map rules ~f:(fun (p, cbs) -> to_untyped p, cbs) in
+    let prog = Matcher.compile pats ~commute:true in
+    prog, VM.create ()
+
+  (* Translate a substitution we got from the matcher
+     into one that our rule callbacks can understand. *)
+  let map_subst_terms t (s : Matcher.subst) : Rv.t S.t =
+    let open S in
+    let regvar id r = match typeof t id with
+      | Some (#Type.basic as ty) -> Regvar (r, ty)
+      | Some `v128 -> Regvar_v r
+      | Some `flag -> Regvar (r, wordb)
       | None -> raise_notrace Mismatch in
-    let rec go env p id k = match p with
-      | P1 (x, xs) -> pat env x xs id k
-      | V1 x -> var env x id k
-    and pat env x xs id k = match node t id with
-      | N (y, ys) when P.equal_op x y ->
-        (* If it fails initially, see if commuting the operands will produce
-           a match. This should cut down on the number of cases we have to
-           cover in our patterns. *)
-        begin try children env xs ys k with
-          | Mismatch when commutable x ->
-            children env xs (List.rev ys) k
-        end
-      | N _ | Rv _ | Tbl _ | Callargs _ -> raise_notrace Mismatch
-    and var env x id k = match node t id with
-      | N (Oaddr a, []) -> k @@ subst env id x @@ Imm (a, wordi)
-      | N (Obool b, []) -> k @@ subst env id x @@ Bool b
-      | N (Odouble d, []) -> k @@ subst env id x @@ Double d
-      | N (Oint (i, ty), []) -> k @@ subst env id x @@ Imm (i, ty)
-      | N (Osingle s, []) -> k @@ subst env id x @@ Single s
-      | N (Osym (s, o), []) -> k @@ subst env id x @@ Sym (s, o)
-      | N (Olocal l, []) -> k @@ subst env id x @@ Label l
-      | Callargs rs -> k @@ subst env id x @@ Callargs rs
-      | Tbl (d, tbl) -> k @@ subst env id x @@ Table (d, tbl)
-      | Rv r -> regvar env x r id k
-      | N _ -> match Hashtbl.find t.id2r id with
-        | None -> raise_notrace Mismatch
-        | Some r -> regvar env x r id k
-    and children env xs ys k = match List.zip xs ys with
-      | Unequal_lengths -> raise_notrace Mismatch
-      | Ok l -> child env k l
-    and child env k = function
-      | [] -> k env
-      | [p, id] -> go env p id k
-      | (p, id) :: xs ->
-        go env p id @@ fun env ->
-        child env k xs in
-    (fun env p id -> go env p id Base.Fn.id),
-    (fun env xs ys -> children env xs ys Base.Fn.id)
+    Map.map s ~f:(fun id ->
+        let tm = match node t id with
+          | N (Oaddr a, []) -> Imm (a, wordi)
+          | N (Obool b, []) -> Bool b
+          | N (Odouble d, []) -> Double d
+          | N (Oint (i, ty), []) -> Imm (i, ty)
+          | N (Osingle s, []) -> Single s
+          | N (Osym (s, o), []) -> Sym (s, o)
+          | N (Olocal l, []) -> Label l
+          | Callargs rs -> Callargs rs
+          | Tbl (d, tbl) -> Table (d, tbl)
+          | Rv r -> regvar id r
+          | N _ -> match Hashtbl.find t.id2r id with
+            | None -> raise_notrace Mismatch
+            | Some r -> regvar id r in
+        S.{id; tm})
+
+  let fail_init_matcher t l id =
+    C.failf "In Isel_match.match_one: at label %a in function $%s: \
+             failed to initialize matcher for node %a (id %d)"
+      Label.pp l (Func.name t.fn) (pp_node t) id id
+
+  let fail_match t l id =
+    C.failf "In Isel_match.match_one: at label %a in function $%s: \
+             failed to produce instructions for node %a (id %d)"
+      Label.pp l (Func.name t.fn) (pp_node t) id id
 
   (* The most general rule `move ?x ?y` needs to exclude cases where ?x and
      ?y refer to the same term, otherwise we will mistakenly achieve coverage
@@ -157,80 +111,33 @@ module Make(M : Machine_intf.S)(C : Context_intf.S) = struct
      result of computing ?y because future instructions may want to match on
      it.
   *)
-  let is_blank_move t env id ps = match node t id with
-    | N (Omove, [_; _]) ->
-      begin match ps with
-        | [V1 x; V1 y] ->
-          begin match Map.find env x, Map.find env y with
-            | Some x, Some y ->
-              let open S in
-              (* This usually isn't the case, but doesn't hurt to check. *)
-              x.id = y.id ||
-              (* They might end up having different IDs, but this should
-                 catch the edge cases. *)
-              equal_term Rv.equal x.tm y.tm
-            | _ -> false
-          end
-        | _ -> false
+  let check_blank_move s n (p : Matcher.pat) = match n, p with
+    | N (Omove, [_; _]),
+      P (Omove, [V x; V y]) ->
+      begin match Map.(find s x, find s y) with
+        | Some x, Some y
+          when x.S.id = y.S.id
+            || S.equal_term Rv.equal x.tm y.tm ->
+          raise_notrace Mismatch
+        | _ -> ()
       end
-    | _ -> false
-
-  let fail_match t l id =
-    C.failf "In Isel_match.match_one: at label %a in function $%s: \
-             failed to produce instructions for node %a (id %d)"
-      Label.pp l (Func.name t.fn) (pp_node t) id id ()
-
-  (* Find the appropriate rules to match against based on the top-level
-     operator of the current node. *)
-  let fetch_rules t l id =
-    let default op cs = match Hashtbl.find tables.other op with
-      | None -> fail_match t l id
-      | Some tls ->
-        Vec.to_sequence_mutable tls |>
-        Seq.map ~f:(fun (ps, posts) ->
-            None, cs, ps, posts) |> C.return in
-    match node t id with
-    | N (Omove, [a; b]) ->
-      begin match node t b with
-        | N (op, cs) ->
-          begin match Hashtbl.find tables.moves op with
-            | None -> default Omove [a; b]
-            | Some tls ->
-              Vec.to_sequence_mutable tls |>
-              Seq.map ~f:(fun (pa, ps, posts) ->
-                  Some (a, pa, op), cs, ps, posts) |> C.return
-          end
-        | Rv _ -> default Omove [a; b]
-        | _ -> fail_match t l id
-      end
-    | N (op, cs) -> default op cs
-    | _ -> fail_match t l id
+    | _ -> ()
 
   let match_one t l id =
-    let* rules = fetch_rules t l id in
-    let go, children = search t in
-    C.Seq.find_map rules ~f:(function
-        | _, _, _, [] ->
-          (* No RHS to produce instructions, so skip it. *)
-          !!None
-        | p, cs, ps, posts ->
-          try
-            (* If this is a specialized move, then produce the env of
-               matching the first argument. *)
-            let env, comm = match p with
-              | None -> S.empty, false
-              | Some (c, p, op) ->
-                (* Do the match first before checking commutativity. *)
-                let env = go S.empty p c in
-                env, commutable op in
-            let env = try children env ps cs with
-              | Mismatch when comm ->
-                children env ps @@ List.rev cs in
-            if Option.is_none p && is_blank_move t env id ps
-            then raise_notrace Mismatch;
-            R.try_ env posts
-          with Mismatch -> !!None) >>= function
-    | None -> fail_match t l id
+    let init = VM.init ~lookup:(node t) vm prog id in
+    let* () = C.unless init @@ fail_init_matcher t l id in
+    let rec loop () = match VM.one vm prog with
+      | None -> !!None
+      | Some y ->
+        try
+          let s = map_subst_terms t @@ Y.subst y in
+          check_blank_move s (node t id) @@ Y.pat y;
+          R.try_ s (Y.payload y) >>= function
+          | Some _ as is -> !!is
+          | None -> loop ()
+        with Mismatch -> loop () in
+    loop () >>= function
+    | None -> fail_match t l id ()
     | Some is -> !!is
 
   (* NB: the list we get from `t.insn` is in reverse order, so a normal

--- a/src/lib/isel/isel_match.ml
+++ b/src/lib/isel/isel_match.ml
@@ -25,7 +25,7 @@ module Make(M : Machine_intf.S)(C : Context_intf.S) = struct
 
   module Matcher = Matcher.Make(struct
       type op = P.op [@@deriving compare, equal, hash, sexp]
-      type term = Rv.t node [@@deriving equal]
+      type term = Rv.t node
       type id = Id.t [@@deriving equal]
 
       let is_commutative = function
@@ -51,6 +51,8 @@ module Make(M : Machine_intf.S)(C : Context_intf.S) = struct
       let term_args = function
         | N (_, args) -> args
         | Rv _ | Tbl _ | Callargs _ -> []
+
+      let term_union _ = None
 
       let pp_id = Id.pp
       let pp_op = P.pp_op

--- a/src/lib/isel/isel_match.ml
+++ b/src/lib/isel/isel_match.ml
@@ -62,9 +62,9 @@ module Make(M : Machine_intf.S)(C : Context_intf.S) = struct
   module Y = Matcher.Yield
 
   let prog, vm =
-    let rec to_untyped : type a b. (a, b) P.t -> Matcher.pat = function
-      | P (op, ps) -> P (op, List.map ps ~f:to_untyped)
-      | V x -> V x in
+    (* XXX: don't try this at home! The representations are exactly the
+       same, but we need to erase the type constraints on the input. *)
+    let to_untyped p = (Obj.magic p : Matcher.pat) in
     let pats = List.map rules ~f:(fun (p, cbs) -> to_untyped p, cbs) in
     let prog = Matcher.compile pats ~commute:true in
     prog, VM.create ()

--- a/src/lib/matcher.ml
+++ b/src/lib/matcher.ml
@@ -1,0 +1,661 @@
+(* Adapted from the paper "Efficient E-matching for SMT Solvers (2007)"
+   by L. de Moura and N. Bjørner *)
+
+open Core
+
+module type L = sig
+  type op [@@deriving compare, equal, hash, sexp]
+  type term [@@deriving equal]
+  type id [@@deriving equal]
+
+  val is_commutative : op -> bool
+
+  val term_op : term -> op option
+  val term_args : term -> id list
+
+  val pp_id : Format.formatter -> id -> unit
+  val pp_op : Format.formatter -> op -> unit
+end
+
+let rec permutations = function
+  | [] -> [[]]
+  | x :: xs ->
+    permutations xs |> List.bind ~f:(fun ys ->
+        List.length ys |> succ |> List.init ~f:(fun i ->
+            let l, r = List.split_n ys i in
+            l @ (x :: r)))
+
+let rec cartesian_product = function
+  | [] -> [[]]
+  | xs :: rest ->
+    List.bind xs ~f:(fun x ->
+        cartesian_product rest |>
+        List.map ~f:(List.cons x))
+
+module Make(M : L) = struct
+  open M
+
+  let is_ground_term t = List.is_empty @@ term_args t
+
+  let term_equal_op t op = match term_op t with
+    | Some op' -> equal_op op op'
+    | None -> false
+
+  module Op = struct
+    type t = op [@@deriving compare, equal, hash, sexp]
+  end
+
+  (* A pattern *)
+  type pat =
+    | V of string
+    | P of op * pat list
+  [@@deriving compare, equal, sexp]
+
+  let make_pats f = List.map ~f:(fun args -> P (f, args))
+  let dedup_pats = List.dedup_and_sort ~compare:compare_pat
+
+  let rec permute_commutative = function
+    | V _ as p -> [p]
+    | P (f, args) ->
+      let sub = List.map args ~f:permute_commutative in
+      let prod = cartesian_product sub in
+      if is_commutative f then
+        List.bind prod ~f:permutations |>
+        make_pats f |> dedup_pats
+      else make_pats f prod
+
+  let rec pp_pat ppf = function
+    | V x -> Format.fprintf ppf "?%s" x
+    | P (op, []) -> Format.fprintf ppf "%a" pp_op op
+    | P (op, ps) ->
+      let pp_sep ppf () = Format.fprintf ppf " " in
+      Format.fprintf ppf "(%a %a)"
+        pp_op op
+        (Format.pp_print_list ~pp_sep pp_pat)
+        ps
+
+  (* VM register *)
+  type reg = {
+    reg : int
+  } [@@unboxed] [@@deriving compare, equal, sexp]
+
+  let (+$) r i = {reg = r.reg + i}
+
+  (* Program label *)
+  type label = {
+    label : int;
+  } [@@unboxed] [@@deriving compare, equal, sexp]
+
+  let nil = {label = -1}
+
+  let pp_reg ppf {reg} = Format.fprintf ppf "$%d" reg
+  let pp_label ppf {label} = Format.fprintf ppf "@%d" label
+
+  (* A VM instruction. *)
+  type insn =
+    (* Start at a new root. This will not be handled in the
+       VM directly, but instead used to initialize the state
+       of the machine for a new term. *)
+    | Init of {
+        f : op;
+        mutable next : label;
+      }
+    (* Match `i` with operator `f`, and if successful, bind its
+       arguments starting at `o` before continuing to `next`. *)
+    | Bind of {
+        i : reg;
+        f : op;
+        o : reg;
+        mutable next : label;
+      }
+    (* Same as `Bind`, but specialized to ground terms. *)
+    | Check of {
+        i : reg;
+        t : op;
+        mutable next : label;
+      }
+    (* Check that `i` and `j` unify to the same term, and if
+       successful, continue to `next`. *)
+    | Compare of {
+        i : reg;
+        j : reg;
+        mutable next : label;
+      }
+    (* Save `alt` as a backtracking point (if available), and
+       continue to next. *)
+    | Choose of {
+        mutable alt : label option;
+        mutable next : label;
+      }
+    (* Yield a successful match; `regs` will be used to build
+       the resulting substitution. *)
+    | Yield of {
+        regs : (reg * string) list;
+        rule : int;
+      }
+  [@@deriving sexp]
+
+  let succs_of_insn = function
+    | Init i' -> [i'.next.label]
+    | Bind b -> [b.next.label]
+    | Check c -> [c.next.label]
+    | Compare c -> [c.next.label]
+    | Choose {alt = None; next} -> [next.label]
+    | Choose {alt = Some a; next} -> [a.label; next.label]
+    | Yield _ -> []
+
+  module Insn = struct
+    let init f = Init {f; next = nil}
+    let bind i f o = Bind {i; f; o; next = nil}
+    let check i t = Check {i; t; next = nil}
+    let compare i j = Compare {i; j; next = nil}
+    let yield regs rule = Yield {regs; rule}
+  end
+
+  let pp_insn ppf = function
+    | Init i ->
+      Format.fprintf ppf "init(%a, %a)" pp_op i.f pp_label i.next
+    | Bind b ->
+      Format.fprintf ppf "bind(%a, %a, %a, %a)"
+        pp_reg b.i pp_op b.f pp_reg b.o pp_label b.next
+    | Check c ->
+      Format.fprintf ppf "check(%a, %a, %a)"
+        pp_reg c.i pp_op c.t pp_label c.next
+    | Compare c ->
+      Format.fprintf ppf "compare(%a, %a, %a)"
+        pp_reg c.i pp_reg c.j pp_label c.next
+    | Choose {alt = None; next} ->
+      Format.fprintf ppf "choose(nil, %a)" pp_label next
+    | Choose {alt = Some a; next} ->
+      Format.fprintf ppf "choose(%a, %a)"
+        pp_label a pp_label next
+    | Yield y ->
+      Format.fprintf ppf "yield(%a) ; rule %d"
+        (Format.pp_print_list
+           (fun ppf (r, x) -> Format.fprintf ppf "%a:?%s" pp_reg r x)
+           ~pp_sep:(fun ppf () -> Format.fprintf ppf ", "))
+        y.regs y.rule
+
+  (* A tree of code sequences. *)
+  type tree =
+    | Leaf of insn
+    | Seq of {
+        insn : insn;
+        next : tree;
+      }
+    | Br of tree Ftree.t
+  [@@deriving sexp]
+
+  let pp_tree ppf t =
+    Format.fprintf ppf "%a" Sexp.pp_hum @@ sexp_of_tree t
+  [@@ocaml.warning "-32"]
+
+  module Tree = struct
+    let leaf insn = Leaf insn
+    let seq insn next = Seq {insn; next}
+    let br alts = Br (Ftree.of_list alts)
+  end
+
+  (* Check if two instructions represent the same operation prefix. *)
+  let compatible a b = match a, b with
+    | Init a, Init b -> equal_op a.f b.f
+    | Bind a, Bind b ->
+      equal_reg a.i b.i && equal_op a.f b.f && equal_reg a.o b.o
+    | Check a, Check b -> 
+      equal_reg a.i b.i && equal_op a.t b.t
+    | Compare a, Compare b ->
+      equal_reg a.i b.i && equal_reg a.j b.j
+    | Yield a, Yield b ->
+      a.rule = b.rule &&
+      List.equal (fun (r1, x1) (r2, x2) ->
+          equal_reg r1 r2 && String.(x1 = x2))
+        a.regs b.regs
+    | _ -> false
+
+  type 'a program = {
+    rule : (pat * 'a) Vec.t;
+    code : insn Vec.t;
+    root : (op, label) Hashtbl.t;
+    rmin : int array;
+  } [@@ocaml.warning "-69"]
+
+  let pp_program ppf p = Vec.iteri p.code ~f:(fun l i ->
+      Format.fprintf ppf "@%d: %a\n" l pp_insn i)
+
+  module Compiler = struct
+    let enqueue_children ?(w = Int.Map.empty) cs o =
+      List.fold cs ~init:(w, o) ~f:(fun (w, o) a ->
+          Map.set w ~key:o ~data:a, o + 1)
+
+    let yield_regs v vars =
+      List.rev @@ List.filter_map vars ~f:(fun x ->
+          Map.find v x |> Option.map ~f:(fun r -> r, x))
+
+    (* Simple heuristic for picking the next pattern.
+
+       The goal is to prioritize patterns that maximize
+       discrimination (i.e. the one that is most likely to fail early).
+    *)
+    let rec depth = function
+      | P (_, args) -> 1 + List.sum (module Int) args ~f:depth
+      | V _ -> 0
+
+    let pick_one w =
+      Map.fold w ~init:None ~f:(fun ~key ~data acc ->
+          let d = depth data in
+          match acc with
+          | Some (_, _, d') when d' >= d -> acc
+          | Some _ | None -> Some (key, data, d))
+
+    (* [v]: a mapping from substitution variables to registers
+
+       [vars]: the current substitution variables in last-seen order
+
+       [a]: the payload for the rule
+
+       [rule]: the ordinal for the rule
+
+       [w]: the current worklist of subpatterns, keyed by their
+       corresponding register
+
+       [o]: the next free register
+    *)
+    let compile_pat ~rule w o =
+      let[@tail_mod_cons] rec go w v o vars =
+        match pick_one w with
+        | None ->
+          (* Worklist is empty. Yield the registers in first-seen
+             variable order. *)
+          [Insn.yield (yield_regs v vars) rule]
+        | Some (i, p, _) ->
+          (* Pop from the worklist. *)
+          let w' = Map.remove w i in
+          match p with
+          | P (t, []) ->
+            (* Ground term. *)
+            Insn.check {reg = i} t :: go w' v o vars
+          | P (f, args) ->
+            let wext, o' = enqueue_children ~w:w' args o in
+            Insn.bind {reg = i} f {reg = o} :: go wext v o' vars
+          | V x ->
+            match Map.find v x with
+            | Some j -> Insn.compare {reg = i} j :: go w' v o vars
+            | None ->
+              (* We haven't seen this variable before, so push it and
+                 continue processing the worklist. *)
+              let v' = Map.set v ~key:x ~data:{reg = i} in
+              go w' v' o (x :: vars) in
+      go w String.Map.empty o []
+
+    let compile_one_rule rule = function
+      | P (f, args) ->
+        let w, o = enqueue_children args 0 in
+        Insn.init f :: compile_pat ~rule w o
+      | V x ->
+        failwithf
+          "compile_one_rule: in rule %d, variable ?%s is at the toplevel"
+          rule x ()
+
+    let (@>) = Ftree.snoc
+
+    (* Create a tree from a sequence of instructions. *)
+    let rec sequentialize = function
+      | [] -> failwith "sequentialize: empty"
+      | [i] -> Tree.leaf i
+      | hd :: tl -> Tree.seq hd @@ sequentialize tl
+
+    (* Insert a sequence of instructions into an existing tree.
+
+       This is intended to enable sharing of subtrees, which can
+       reduce both the final code size and the cost of backtracking
+       during execution.
+    *)
+    let rec insert p t = match p, t with
+      | [], t ->
+        (* Reached the end of the rule. Return the existing tree. *)
+        t, false
+      | insn :: rest, Seq s ->
+        (* Existing sequential node. *)
+        if compatible insn s.insn then
+          (* Shared prefix: continue downward. *)
+          let next, _ = insert rest s.next in
+          Seq {s with next}, true
+        else
+          (* Divergence: branch here. *)
+          Tree.br [t; sequentialize p], false
+      | _ :: _, Br alts ->
+        (* Existing branch node: see if any alternatives can
+           be merged with the program. *)
+        let any = ref false in
+        let alts = Ftree.map alts ~f:(fun a ->
+            (* Only extend the first matching alternative. *)
+            if !any then a else match insert p a with
+              | a', true -> any := true; a'
+              | _ -> a) in
+        (* If none matched, then the program just becomes a
+           new alternative. *)
+        let alts = if !any then alts
+          else alts @> sequentialize p in
+        Br alts, !any
+      | _ :: _, Leaf _ ->
+        (* Existing leaf: no continuation to descend. *)
+        Tree.br [t; sequentialize p], false
+
+    let emit code i =
+      let label = Vec.length code in
+      Vec.push code i;
+      {label}
+
+    let patch_next_at code i next =
+      match Vec.get_exn code i.label with
+      | Init i -> i.next <- next
+      | Bind b -> b.next <- next
+      | Check c -> c.next <- next
+      | Compare c -> c.next <- next
+      | Choose _ | Yield _ -> assert false
+
+    let patch_choose_alt_at code i alt =
+      match Vec.get_exn code i.label with
+      | Choose c -> c.alt <- alt
+      | _ -> assert false
+
+    let linearize code t =
+      let rec go = function
+        | Leaf insn -> emit code insn
+        | Seq s ->
+          let label = emit code s.insn in
+          patch_next_at code label @@ go s.next;
+          label
+        | Br alts ->
+          assert (not @@ Ftree.is_empty alts);
+          (* Emit a `choose` instruction for each alternative. *)
+          let alts = Ftree.map alts ~f:(fun a ->
+              emit code @@ Choose {alt = None; next = go a}) in
+          (* Every alternative but the last one will have its
+             next one as a continuation for its subtree. *)
+          Ftree.fold_right alts ~init:None ~f:(fun ch alt ->
+              patch_choose_alt_at code ch alt;
+              Some ch) |> ignore;
+          (* Start with the first alternative. *)
+          Ftree.head_exn alts in
+      go t
+
+    (* Compute a backtracking priority for each program label.
+
+       In this case, we want `yield` instructions to be visited
+       in rule ID (insertion) order when we run the VM.
+    *)
+    let compute_rmin code =
+      let n = Vec.length code in
+      (* Compute the control-flow graph. *)
+      let succs = Array.init n ~f:(fun i ->
+          succs_of_insn @@ Vec.get_exn code i) in
+      let preds = Array.create ~len:n [] in
+      Array.iteri succs ~f:(fun i ss ->
+          List.iter ss ~f:(fun s ->
+              preds.(s) <- i :: preds.(s)));
+      (* Seed the worklist with all `yield` instructions. *)
+      let inf = Int.max_value in
+      let rmin = Array.create ~len:n inf in
+      let q = Stack.create () in
+      Vec.iteri code ~f:(fun i -> function
+          | Yield y ->
+            rmin.(i) <- y.rule;
+            Stack.push q i
+          | _ -> ());
+      (* Merge function. *)
+      let min_succ i = List.fold succs.(i) ~init:inf
+          ~f:(fun acc j -> Int.min acc rmin.(j)) in
+      let yield_at i = match Vec.get_exn code i with
+        | Yield y -> y.rule
+        | _ -> inf in
+      let merge p = Int.min (yield_at p) (min_succ p) in
+      (* Perform a backwards-flow analysis until we reach a
+         fixed point. *)
+      Stack.until_empty q (fun v ->
+          List.iter preds.(v) ~f:(fun p ->
+              let m = merge p in
+              if m < rmin.(p) then begin
+                rmin.(p) <- m;
+                Stack.push q p
+              end));
+      rmin
+
+    let compile_tree forest i pat =
+      match compile_one_rule i pat with
+      | (Init i :: _) as p ->
+        (* Trees that share the same root can be merged together. *)
+        Hashtbl.update forest i.f ~f:(function
+            | Some t -> fst @@ insert p t
+            | None -> sequentialize p)
+      | _ :: _ ->
+        failwithf "compile_tree: invalid root at rule %d" i ()
+      | [] ->
+        failwithf "compile_tree: empty sequence at rule %d" i ()
+
+    let compile ?(commute = false) rules =
+      let rule = Vec.of_list rules in
+      let code = Vec.create () in
+      let root = Hashtbl.create (module Op) in
+      let forest = Hashtbl.create (module Op) in
+      let rmin = match rules with
+        | [] -> [||]
+        | _ ->
+          if commute then
+            Vec.iteri rule ~f:(fun i (pat, _) ->
+                permute_commutative pat |>
+                List.iter ~f:(compile_tree forest i))
+          else
+            Vec.iteri rule ~f:(fun i (pat, _) ->
+                compile_tree forest i pat);
+          Hashtbl.iteri forest ~f:(fun ~key ~data ->
+              let data = linearize code data in
+              Hashtbl.set root ~key ~data);
+          compute_rmin code in
+      {rule; code; root; rmin}
+  end
+
+  let compile = Compiler.compile
+
+  type subst = id String.Map.t
+
+  type 'a yield = {
+    subst : subst;
+    payload : 'a;
+    rule : int;
+    pat : pat;
+  }
+
+  let pp_yield_dbg ppn ppf y =
+    Format.fprintf ppf "rule %d:\n" y.rule;
+    Format.fprintf ppf "pattern: %a\n" pp_pat y.pat;
+    if Map.is_empty y.subst then
+      Format.fprintf ppf "subst = {}\n"
+    else begin
+      Format.fprintf ppf "subst = {\n";
+      Map.iteri y.subst ~f:(fun ~key:x ~data:id ->
+          Format.fprintf ppf "  %s = %a, id %a\n" x ppn id pp_id id);
+      Format.fprintf ppf "}\n"
+    end
+
+  module Yield = struct
+    type 'a t = 'a yield
+    let subst y = y.subst
+    let payload y = y.payload
+    let rule y = y.rule
+    let pat y = y.pat
+  end
+
+  module VM = struct
+    exception Finished
+
+    type regs = id Option_array.t
+
+    type frame = {
+      pc : label;
+      regs : regs;
+      rule : int;
+    }
+
+    let frame_order f1 f2 = Int.compare f1.rule f2.rule
+
+    type state = {
+      mutable pc : label;
+      mutable regs : regs;
+      mutable lookup : id -> term;
+      cont : frame Pairing_heap.t;
+    }
+
+    let default_lookup _ =
+      failwith "VM: term lookup is uninitialized"
+
+    let create () = {
+      pc = nil;
+      lookup = default_lookup;
+      regs = Option_array.create ~len:16;
+      cont = Pairing_heap.create ~cmp:frame_order ();
+    }
+
+    let snapshot_regs st = Option_array.copy st.regs
+
+    let reset st =
+      st.pc <- nil;
+      st.lookup <- default_lookup;
+      Option_array.clear st.regs;
+      Pairing_heap.clear st.cont
+
+    let push_frame prog st pc =
+      Pairing_heap.add st.cont {
+        pc;
+        regs = snapshot_regs st;
+        rule = prog.rmin.(pc.label);
+      }
+
+    let backtrack st = match Pairing_heap.pop st.cont with
+      | None ->
+        reset st;
+        raise_notrace Finished
+      | Some f ->
+        st.regs <- f.regs;
+        st.pc <- f.pc
+
+    let (.$[]) st r = match Option_array.get st.regs r.reg with
+      | None -> failwithf "VM: register $%d is uninitialized" r.reg ()
+      | Some t -> t
+
+    let (.$[]<-) st r x =
+      Option_array.set_some st.regs r.reg x
+
+    let ensure_regs st need =
+      let n = need + 1 in
+      if Option_array.length st.regs < n then
+        let current_len = Option_array.length st.regs in
+        let new_len = max n (2 * current_len + 1) in
+        let bigger = Option_array.create ~len:new_len in
+        Option_array.blit
+          ~src:st.regs ~src_pos:0
+          ~dst:bigger ~dst_pos:0
+          ~len:current_len;
+        st.regs <- bigger
+
+    let load_args st r t =
+      let args = term_args t in
+      let len = List.length args in
+      if len > 0 then begin
+        ensure_regs st (r.reg + len);
+        List.iteri args ~f:(fun i t -> st.$[r +$ i] <- t)
+      end;
+      len
+
+    (* pre: each `x` should be unique *)
+    let make_subst st regs : subst =
+      List.fold regs ~init:String.Map.empty
+        ~f:(fun s (r, x) -> Map.set s ~key:x ~data:st.$[r])
+
+    type 'a result =
+      | Continue
+      | Yield of 'a yield
+
+    let bind st o t next =
+      ignore @@ load_args st o t;
+      st.pc <- next
+
+    let step st prog =
+      if equal_label st.pc nil then
+        raise_notrace Finished;
+      match Vec.get_exn prog.code st.pc.label with
+      | Init _ ->
+        (* NB: this should be done manually at the toplevel *)
+        assert false
+      | Bind b ->
+        let t = st.lookup st.$[b.i] in
+        if term_equal_op t b.f
+        then bind st b.o t b.next
+        else backtrack st;
+        Continue
+      | Check c ->
+        let t = st.lookup st.$[c.i] in
+        if is_ground_term t && term_equal_op t c.t
+        then st.pc <- c.next
+        else backtrack st;
+        Continue
+      | Choose c ->
+        Option.iter c.alt ~f:(push_frame prog st);
+        st.pc <- c.next;
+        Continue
+      | Compare c ->
+        let i = st.$[c.i] in
+        let j = st.$[c.j] in
+        if equal_id i j
+        then st.pc <- c.next
+        else backtrack st;
+        Continue
+      | Yield y ->
+        let subst = make_subst st y.regs in
+        let pat, payload = Vec.get_exn prog.rule y.rule in
+        Yield {subst; payload; rule = y.rule; pat}
+
+    let (let-) x f = match x with
+      | Some y -> f y
+      | None -> false
+
+    let init ~lookup st prog id =
+      let t = lookup id in
+      let- op = term_op t in
+      let- r = Hashtbl.find prog.root op in
+      match Vec.get_exn prog.code r.label with
+      | Init i ->
+        assert (equal_op op i.f);
+        st.pc <- i.next;
+        st.lookup <- lookup;
+        let n = load_args st {reg = 0} t in
+        for i = n to Option_array.length st.regs - 1 do
+          Option_array.set_none st.regs i;
+        done;
+        Pairing_heap.clear st.cont;
+        true
+      | _ -> assert false
+
+    let many ?limit st prog =
+      let result = ref [] in
+      let count = ref 0 in
+      let limit = Option.value limit ~default:Int.max_value in
+      let continue = ref true in
+      while !continue && !count < limit do
+        try match step st prog with
+          | Continue -> ()
+          | Yield y ->
+            result := y :: !result;
+            incr count;
+            backtrack st
+        with Finished -> continue := false
+      done;
+      List.rev !result
+
+    let one st prog =
+      match many ~limit:1 st prog with
+      | [] -> None
+      | [y] -> Some y
+      | _ -> assert false
+  end
+end

--- a/src/lib/matcher.mli
+++ b/src/lib/matcher.mli
@@ -7,7 +7,7 @@ module type L = sig
 
   (** A term, which is the subject of attempting to match
       against a pattern. *)
-  type term [@@deriving equal]
+  type term
 
   (** An identifier for a term.
 
@@ -31,6 +31,18 @@ module type L = sig
   *)
   val term_args : term -> id list
 
+  (** If this term is a {i union} of two terms (i.e. an equivalence class),
+      then return the pair of node IDs that represents the equivalence.
+
+      The first element is the {i pre} term, and the second element is the
+      {i post} term
+
+      The {i post} term represents the newer term, and will be prioritized
+      in when looking for matches. Meanwhile, the {i pre} term will be
+      bookmarked for later exploration.
+  *)
+  val term_union : term -> (id * id) option
+
   (** Pretty-print a term ID. *)
   val pp_id : Format.formatter -> id -> unit
 
@@ -53,7 +65,7 @@ module Make(M : L) : sig
   type pat =
     | V of string
     | P of op * pat list
-  [@@deriving sexp]
+  [@@deriving compare, equal, hash, sexp]
 
   val pp_pat : Format.formatter -> pat -> unit
 

--- a/src/lib/matcher.mli
+++ b/src/lib/matcher.mli
@@ -1,0 +1,155 @@
+open Core
+
+(** The input language. *)
+module type L = sig
+  (** The type for operations in the input language. *)
+  type op [@@deriving compare, equal, hash, sexp]
+
+  (** A term, which is the subject of attempting to match
+      against a pattern. *)
+  type term [@@deriving equal]
+
+  (** An identifier for a term.
+
+      It is assumed that terms are interned as [id]s.
+  *)
+  type id [@@deriving equal]
+
+  (** Returns [true] if the [op] has the commutative property.
+
+      It is assumed that commutative [op]s are always binary
+      in their operands.
+  *)
+  val is_commutative : op -> bool
+
+  (** Return the [op] of the term, if applicable. *)
+  val term_op : term -> op option
+
+  (** Return the arguments (children) of the term.
+
+      If the term has no arguments, then it is considered a {i ground} term.
+  *)
+  val term_args : term -> id list
+
+  (** Pretty-print a term ID. *)
+  val pp_id : Format.formatter -> id -> unit
+
+  (** Pretty-print an operation. *)
+  val pp_op : Format.formatter -> op -> unit
+end
+
+(** Create a matcher. *)
+module Make(M : L) : sig
+  open M
+
+  (** A pattern to be inserted in to the matcher.
+
+      [V x]: a substitution variable [x]
+
+      [P (op, children)]: a concrete pattern for operation [op],
+      with arguments [children] as subpatterns. If [children = []],
+      then this is considered a {i ground} pattern.
+  *)
+  type pat =
+    | V of string
+    | P of op * pat list
+  [@@deriving sexp]
+
+  val pp_pat : Format.formatter -> pat -> unit
+
+  (** A compiled VM program. *)
+  type 'a program
+
+  (** Pretty-print the program. *)
+  val pp_program : Format.formatter -> 'a program -> unit
+
+  (** Compile a set of rules into a program.
+
+      Each rule is a pattern [pat], and an associated payload
+      for when [pat] successfully matches.
+
+      If [commute] is [true] (default is [false]), then patterns
+      will be expanded/permuted according to [M.is_commutative].
+      This can substantially increase the size of the compiled
+      program.
+
+      The rules are assumed to be in an {i optimal} priority order,
+      and the [VM] (see below) will prioritize yielding matches in
+      this order.
+  *)
+  val compile : ?commute:bool -> (pat * 'a) list -> 'a program
+
+  (** A substitution.
+
+      Keys are substitution variables, and values are the [term]-[id] pairs.
+  *)
+  type subst = id String.Map.t
+
+  (** A successful match. *)
+  type 'a yield
+
+  (** Debug printing for a yield.
+
+      The first argument is a pretty-printer for terms, given an id.
+  *)
+  val pp_yield_dbg :
+    (Format.formatter -> id -> unit) ->
+    Format.formatter ->
+    'a yield ->
+    unit
+
+  module Yield : sig
+    type 'a t = 'a yield
+
+    (** The resulting substitution. *)
+    val subst : 'a t -> subst
+
+    (** The resulting payload. *)
+    val payload : 'a t -> 'a
+
+    (** The rule ordinal that produced the result. *)
+    val rule : 'a t -> int
+
+    (** The pattern that was matched. *)
+    val pat : 'a t -> pat
+  end
+
+  (** A virtual machine (VM) for running a compiled program. *)
+  module VM : sig
+    (** Internal VM state. *)
+    type state
+
+    (** Create a VM state. *)
+    val create : unit -> state
+
+    (** Reset the VM state.
+
+        This should be done after all matching on a single term
+        is completed.
+    *)
+    val reset : state -> unit
+
+    (** Initializes the state for incremental execution on a
+        single term.
+
+        Returns [true] if the initialization was successful.
+    *)
+    val init : lookup:(id -> term) -> state -> 'a program -> id -> bool
+
+    (** Attempts to produce a single match.
+
+        Returns [None] if the term had no matches.
+    *)
+    val one : state -> 'a program -> 'a yield option
+
+    (** A generalized version of [one].
+
+        The reulting list of matches is provided in the order of the
+        provided rules during compilation.
+
+        An optional [limit] on the number of matches can be provided. If
+        this is less than [1], then no matches will be produced.
+    *)
+    val many : ?limit:int -> state -> 'a program -> 'a yield list
+  end
+end

--- a/src/lib/passes/egraph_opt/egraph_opt_rules.ml
+++ b/src/lib/passes/egraph_opt/egraph_opt_rules.ml
@@ -2041,5 +2041,5 @@ module Groups = struct
     ]
 end
 
-let all = Egraph.create_table Groups.all
-let none = Egraph.create_table []
+let all = Egraph.compile Groups.all
+let none = Egraph.compile []

--- a/src/test/data/opt/spill1.vir.opt.sysv.amd64.regalloc
+++ b/src/test/data/opt/spill1.vir.opt.sysv.amd64.regalloc
@@ -96,18 +96,19 @@ export function $foo { ; returns: rax
   mov dword ptr [rsp + 0x3c], eax ; @233
   jmp @3 ; @155
 @21:
-  mov ecx, dword ptr [rsp + 0x30] ; @235
-  mov eax, dword ptr [rsp + 0x34] ; @234
-  lea esi, qword ptr [rcx + rax*1] ; @125
+  mov ecx, dword ptr [rsp + 0x38] ; @235
+  mov eax, dword ptr [rsp + 0x3c] ; @234
+  lea esi, qword ptr [rcx + rax*1] ; @127
   mov eax, dword ptr [rsp + 0x28] ; @237
   mov ecx, dword ptr [rsp + 0x2c] ; @236
   lea edi, qword ptr [rax + rcx*1] ; @123
-  mov eax, dword ptr [rsp + 0x38] ; @239
-  mov ecx, dword ptr [rsp + 0x3c] ; @238
-  lea edx, qword ptr [rax + rcx*1 + 0x15] ; @128
-  mov ecx, dword ptr [rsp + 0x20] ; @241
-  add ecx, dword ptr [rsp + 0x24] ; @121
-  lea edx, qword ptr [rdx + rsi*1 + 0xf] ; @129
+  mov eax, dword ptr [rsp + 0x20] ; @239
+  mov ecx, dword ptr [rsp + 0x24] ; @238
+  add ecx, eax ; @121
+  mov edx, dword ptr [rsp + 0x30] ; @241
+  mov eax, dword ptr [rsp + 0x34] ; @240
+  lea eax, qword ptr [rdx + rax*1 + 0xf] ; @126
+  lea edx, qword ptr [rax + rsi*1 + 0x15] ; @129
   mov eax, dword ptr [rsp + 0x18] ; @243
   mov esi, dword ptr [rsp + 0x1c] ; @242
   add esi, eax ; @119

--- a/src/test/data/opt/spill1.vir.opt.sysv.amd64.regalloc
+++ b/src/test/data/opt/spill1.vir.opt.sysv.amd64.regalloc
@@ -96,34 +96,33 @@ export function $foo { ; returns: rax
   mov dword ptr [rsp + 0x3c], eax ; @233
   jmp @3 ; @155
 @21:
-  mov ecx, dword ptr [rsp + 0x38] ; @235
-  mov eax, dword ptr [rsp + 0x3c] ; @234
-  lea edx, qword ptr [rcx + rax*1] ; @127
-  mov eax, dword ptr [rsp + 0x30] ; @237
-  mov ecx, dword ptr [rsp + 0x34] ; @236
-  lea eax, qword ptr [rax + rcx*1 + 0xf] ; @126
-  lea ecx, qword ptr [rax + rdx*1 + 0x15] ; @129
-  mov eax, dword ptr [rsp + 0x28] ; @239
-  mov edx, dword ptr [rsp + 0x2c] ; @238
-  lea eax, qword ptr [rax + rdx*1 + 0x13] ; @124
-  add eax, ecx ; @130
-  mov edx, dword ptr [rsp + 0x20] ; @241
-  mov ecx, dword ptr [rsp + 0x24] ; @240
-  lea ecx, qword ptr [rdx + rcx*1 + 0x17] ; @122
-  lea edx, qword ptr [rcx + rax*1] ; @131
-  mov eax, dword ptr [rsp + 0x8] ; @243
-  mov ecx, dword ptr [rsp + 0xc] ; @242
+  mov ecx, dword ptr [rsp + 0x30] ; @235
+  mov eax, dword ptr [rsp + 0x34] ; @234
+  lea esi, qword ptr [rcx + rax*1] ; @125
+  mov eax, dword ptr [rsp + 0x28] ; @237
+  mov ecx, dword ptr [rsp + 0x2c] ; @236
+  lea edi, qword ptr [rax + rcx*1] ; @123
+  mov eax, dword ptr [rsp + 0x38] ; @239
+  mov ecx, dword ptr [rsp + 0x3c] ; @238
+  lea edx, qword ptr [rax + rcx*1 + 0x15] ; @128
+  mov ecx, dword ptr [rsp + 0x20] ; @241
+  add ecx, dword ptr [rsp + 0x24] ; @121
+  lea edx, qword ptr [rdx + rsi*1 + 0xf] ; @129
+  mov eax, dword ptr [rsp + 0x18] ; @243
+  mov esi, dword ptr [rsp + 0x1c] ; @242
+  add esi, eax ; @119
+  lea eax, qword ptr [rdx + rdi*1 + 0x13] ; @130
+  mov edx, dword ptr [rsp + 0x10] ; @245
+  mov edi, dword ptr [rsp + 0x14] ; @244
+  add edi, edx ; @117
+  lea edx, qword ptr [rax + rcx*1 + 0x17] ; @131
+  mov eax, dword ptr [rsp + 0x8] ; @247
+  mov ecx, dword ptr [rsp + 0xc] ; @246
   add ecx, eax ; @115
-  mov eax, dword ptr [rsp + 0x18] ; @245
-  mov esi, dword ptr [rsp + 0x1c] ; @244
-  lea eax, qword ptr [rax + rsi*1 + 0x1b] ; @120
-  lea edi, qword ptr [rax + rdx*1] ; @132
-  mov eax, dword ptr [rsp] ; @247
+  lea esi, qword ptr [rdx + rsi*1 + 0x1b] ; @132
+  mov eax, dword ptr [rsp] ; @249
   add eax, dword ptr [rsp + 0x4] ; @114
-  mov edx, dword ptr [rsp + 0x10] ; @249
-  mov esi, dword ptr [rsp + 0x14] ; @248
-  lea edx, qword ptr [rdx + rsi*1 + 0x1f] ; @118
-  add edx, edi ; @133
+  lea edx, qword ptr [rsi + rdi*1 + 0x1f] ; @133
   add eax, ecx ; @116
   add eax, edx ; @134
   add rsp, 0x50_l ; @256


### PR DESCRIPTION
This is based on the [paper](https://leodemoura.github.io/files/ematching.pdf) "Efficient E-matching for SMT Solvers" by de Moura & Bjørner.

The idea is to compile a set of tree patterns ahead of time, as a group, and then exploit sharing of subtrees across these patterns to produce an efficient tree-matching program for a bespoke virtual machine.

This implementation is generic enough to be re-used in the e-graph and instruction selection modules.

The results are two-fold:

1. Running the compiled programs is very fast
2. Compiling the patterns to a program incurs a fixed overhead cost

As a result of this overhead, most of the tiny examples in the testsuite will have a slightly slower wall-clock time, but this approach is likely to scale much better for larger input programs.