### PR TITLE
Refactor `test_opt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ SRC := ./src/
 
 all: install
 
+export UPDATE_EXPECT
+
 build:
 	$(MAKE) -C $(SRC)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,7 @@
 .PHONY: clean install uninstall test doc deps bap-deps
 
+UPDATE_EXPECT ?= 0
+
 PROFILE = release
 ifeq ($(DEBUG),1)
 	PROFILE = dev
@@ -29,7 +31,7 @@ uninstall:
 	dune uninstall
 
 test:
-	dune test --profile=$(PROFILE)
+	UPDATE_EXPECT=$(UPDATE_EXPECT) dune test --profile=$(PROFILE)
 
 doc:
 	dune build @doc

--- a/src/cgen.opam
+++ b/src/cgen.opam
@@ -16,6 +16,7 @@ depends: [
   "cmdliner"
   "core" {>= "v0.15"}
   "core_kernel" {>= "v0.15"}
+  "core_unix" {>= "v0.15"}
   "dune" {>= "3.15"}
   "fmt"
   "graphlib"

--- a/src/dune-project
+++ b/src/dune-project
@@ -22,6 +22,7 @@
     cmdliner
     (core (>= v0.15))
     (core_kernel (>= v0.15))
+    (core_unix (>= v0.15))
     dune
     fmt
     graphlib

--- a/src/lib/allen_interval_algebra.ml
+++ b/src/lib/allen_interval_algebra.ml
@@ -46,7 +46,7 @@ module type S = sig
 
   (** An inclusive interval.
 
-      Invariant: [lo t <= hi t]
+      Invariant: [lo t < hi t]
   *)
   type t
 

--- a/src/lib/passes/coalesce_slots/coalesce_slots_impl.ml
+++ b/src/lib/passes/coalesce_slots/coalesce_slots_impl.ml
@@ -31,7 +31,7 @@ module Range = struct
   let bad = {lo = Int.min_value; hi = Int.max_value; tg = Both}
   let is_bad = equal bad
 
-  let singleton n = {lo = n; hi = n; tg = Def}
+  let singleton n = {lo = n; hi = n + 1; tg = Def}
   let size r = r.hi - r.lo
 
   let distance x y =
@@ -43,7 +43,7 @@ module Range = struct
   (* Extend the upper-bound on the live range. *)
   let use r n = {
     r with
-    hi = Int.max r.hi n;
+    hi = Int.max r.hi (n + 1);
     tg = join_tag r.tg Use;
   }
 
@@ -54,7 +54,7 @@ module Range = struct
   *)
   let def r n = {
     lo = Int.min r.lo n;
-    hi = Int.max r.hi n;
+    hi = Int.max r.hi (n + 1);
     tg = join_tag r.tg Def;
   }
 
@@ -100,7 +100,7 @@ let compat_range x y =
       m "%s: %a, %a: %a%!" __FUNCTION__
         Var.pp x.var Var.pp y.var Allen.pp a);
   match a with
-  | Before | After -> true
+  | Before | After | Meets | Met_by -> true
   | _ -> false
 
 let range_priority x y =

--- a/src/lib/passes/sroa/sroa_impl.ml
+++ b/src/lib/passes/sroa/sroa_impl.ml
@@ -59,7 +59,7 @@ module Partition = struct
 
   let range p = {
     lo = p.off;
-    hi = Int64.(p.off + p.size);
+    hi = Int64.(p.off + max 1L p.size);
   } [@@inline]
 
   let pp ppa ppf p =
@@ -103,7 +103,7 @@ end = struct
 
     let range a = {
       lo = a.off;
-      hi = Int64.(a.off + of_int (sizeof a));
+      hi = Int64.(a.off + max 1L (of_int (sizeof a)));
     } [@@inline]
 
     let pp ppf a =

--- a/src/test/dune
+++ b/src/test/dune
@@ -1,10 +1,22 @@
-(tests
- (names test_allen test_opt test_type)
- (libraries ocamldiff ounit2 cgen shexp.process)
- (modules test_allen test_opt test_type)
+(test
+ (name test_opt)
+ (libraries cgen golden ocamldiff ounit2 process)
+ (modules test_opt)
  (ocamlopt_flags -O2)
  (deps
   (glob_files_rec data/*)))
+
+(test
+ (name test_allen)
+ (libraries cgen ounit2)
+ (modules test_allen)
+ (ocamlopt_flags -O2))
+
+(test
+ (name test_type)
+ (libraries cgen ounit2)
+ (modules test_type)
+ (ocamlopt_flags -O2))
 
 (library
  (name test_float32)
@@ -32,3 +44,15 @@
  (inline_tests)
  (preprocess
   (pps ppx_jane)))
+
+(library
+ (name golden)
+ (libraries core core_unix core_unix.filename_unix ocamldiff)
+ (modules golden)
+ (ocamlopt_flags -O2))
+
+(library
+ (name process)
+ (libraries core shexp.process)
+ (modules process)
+ (ocamlopt_flags -O2))

--- a/src/test/dune
+++ b/src/test/dune
@@ -7,16 +7,19 @@
   (glob_files_rec data/*)))
 
 (test
- (name test_allen)
- (libraries cgen ounit2)
- (modules test_allen)
- (ocamlopt_flags -O2))
-
-(test
  (name test_type)
  (libraries cgen ounit2)
  (modules test_type)
  (ocamlopt_flags -O2))
+
+(library
+ (name test_allen)
+ (libraries cgen)
+ (modules test_allen)
+ (ocamlopt_flags -O2)
+ (inline_tests)
+ (preprocess
+   (pps ppx_jane)))
 
 (library
  (name test_float32)

--- a/src/test/golden.ml
+++ b/src/test/golden.ml
@@ -1,0 +1,49 @@
+open Core
+
+let exists f = match Sys_unix.file_exists f with
+  | `No | `Unknown -> false
+  | `Yes -> true
+
+let rec find_project_root dir =
+  let dune_file = Filename.concat dir "dune-project" in
+  if exists dune_file then dir else
+    let parent = Filename.dirname dir in
+    if Filename.(parent = dir)
+    then failwith "Could not find dune-project file"
+    else find_project_root parent
+
+let project_root =
+  find_project_root @@
+  Filename_unix.realpath @@
+  Filename.current_dir_name
+
+let test_root = Filename.concat project_root "test"
+
+let should_update = match Sys.getenv "UPDATE_EXPECT" with
+  | Some ("1" | "true" | "yes") -> true
+  | _ -> false
+
+let write path data =
+  assert (Filename.is_relative path);
+  let path = Filename.concat test_root path in
+  let dir = Filename.dirname path in
+  if not (exists dir) then Core_unix.mkdir dir ~perm:0o755;
+  Out_channel.write_all path ~data
+
+let compare_or_update ?(chop_end = true) ~fail ~expected_file ~actual () =
+  if not (exists expected_file) then
+    write expected_file (actual ^ "\n")
+  else
+    let expected = In_channel.read_all expected_file in
+    let expected = if not chop_end then expected
+      else String.chop_suffix_if_exists expected ~suffix:"\n" in
+    if String.(expected <> actual) then
+      if should_update then
+        write expected_file (actual ^ "\n")
+      else
+        let diff =
+          Odiff.strings_diffs expected actual |>
+          Odiff.string_of_diffs in
+        fail @@ Format.sprintf
+          "Output mismatch in %s:\n%s"
+          expected_file diff

--- a/src/test/process.ml
+++ b/src/test/process.ml
@@ -1,0 +1,22 @@
+open Core
+
+type proc = {
+  code   : Shexp_process.Exit_status.t;
+  stdout : string;
+  stderr : string;
+}
+
+let run cmd args =
+  let open Shexp_process in
+  let open Shexp_process.Infix in
+  eval @@
+  with_temp_file ~prefix:"stdout" ~suffix:".log" @@ fun stdout_file ->
+  with_temp_file ~prefix:"stderr" ~suffix:".log" @@ fun stderr_file ->
+  stdout_to stdout_file @@
+  stderr_to stderr_file @@
+  run_exit_status cmd args >>= fun code ->
+  return {
+    code;
+    stdout = In_channel.read_all stdout_file;
+    stderr = In_channel.read_all stderr_file;
+  }

--- a/src/test/test_allen.ml
+++ b/src/test/test_allen.ml
@@ -1,47 +1,153 @@
 open Core
-open OUnit2
 open Cgen
 open Allen_interval_algebra
+
+module Seq = Sequence
+module Q = Quickcheck
+module G = Q.Generator
+module S = Q.Shrinker
+module O = Q.Observer
+module T = Base_quickcheck.Test
 
 type range = {
   lo : int;
   hi : int;
-}
+} [@@deriving sexp]
 
 let (--) lo hi = {lo; hi}
 
-module A = Make(struct
-    type point = int
-    type t = range
-    let lo t = t.lo
-    let hi t = t.hi
-    include Int.Replace_polymorphic_compare
-  end)
+module R = struct
+  type point = int
+  type t = range
+  let lo t = t.lo
+  let hi t = t.hi
+  include Int.Replace_polymorphic_compare
+end
 
-let printer = Format.asprintf "%a" pp
+module A = Make(R)
 
-let test expect a b _ =
-  let got = A.relate a b in
-  assert_equal ~printer expect got;
-  let expect' = converse expect in
-  let got' = A.relate b a in
-  assert_equal ~msg:"Converse" ~printer expect' got'
+let rels a b = A.[|
+    before a b;
+    meets a b;
+    overlaps a b;
+    finished_by a b;
+    contains a b;
+    starts a b;
+    equal a b;
+    started_by a b;
+    during a b;
+    finishes a b;
+    overlapped_by a b;
+    met_by a b;
+    after a b;
+  |]
 
-let suite =
-  "Allen interval algebra" >::: [
-    "before" >:: test Before (1--3) (5--7);
-    "meets" >:: test Meets (1--3) (3--8);
-    "overlaps" >:: test Overlaps (1--5) (3--8);
-    "finished_by" >:: test Finished_by (1--10) (4--10);
-    "contains" >:: test Contains (1--10) (3--7);
-    "starts" >:: test Starts (1--3) (1--10);
-    "equal" >:: test Equal (2--7) (2--7);
-    "started_by" >:: test Started_by (1--10) (1--3);
-    "during" >:: test During (4--6) (1--10);
-    "finishes" >:: test Finishes (4--10) (1--10);
-    "overlapped_by" >:: test Overlapped_by (5--10) (1--7);
-    "met_by" >:: test Met_by (10--15) (5--10);
-    "after" >:: test After (10--15) (1--7);
-  ]
+let range_ok r =
+  r.lo >= -500 && r.lo < r.hi && r.hi <= 500
 
-let () = run_test_tt_main suite
+let gen_range =
+  G.map2 Int.quickcheck_generator Int.quickcheck_generator ~f:((--)) |>
+  G.filter ~f:range_ok
+
+let obs_range =
+  O.(unmap
+       (tuple2
+          Int.quickcheck_observer
+          Int.quickcheck_observer))
+    ~f:(fun {lo; hi} -> lo, hi)
+
+let shr_range = S.create @@ fun {lo; hi} ->
+  S.(shrink
+       (tuple2
+          Int.quickcheck_shrinker
+          Int.quickcheck_shrinker))
+    (lo, hi) |>
+  Seq.filter_map ~f:(fun (lo, hi) ->
+      let r = {lo; hi} in
+      if range_ok r then Some r else None)
+
+let gen_pair = G.map2 gen_range gen_range ~f:Tuple2.create
+
+module Pair = struct
+  type t = range * range [@@deriving sexp]
+  let quickcheck_generator = gen_pair
+  let quickcheck_observer = O.tuple2 obs_range obs_range
+  let quickcheck_shrinker = S.tuple2 shr_range shr_range
+end
+
+let%test_unit "valid allen relation" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      match A.relate a b with
+      | Before | Meets | Overlaps | Finished_by
+      | Contains | Starts | Equal | Started_by
+      | During | Finishes | Overlapped_by | Met_by | After -> ())
+
+let%test_unit "converse law" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      let r_ab = A.relate a b in
+      let r_ba = A.relate b a in
+      let r_ab' = converse r_ab in
+      assert (equal r_ab' r_ba))
+
+let%test_unit "reflexive: only equal when identical" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      if a.lo = b.lo && a.hi = b.hi then
+        assert (equal (A.relate a b) Equal)
+      else
+        assert (not (equal (A.relate a b) Equal)))
+
+let%test_unit "exclusive relation" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      assert (Array.count (rels a b) ~f:Fn.id = 1))
+
+let%test_unit "converse table is correct" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      let r = A.relate a b in
+      let r' = A.relate b a in
+      assert (equal (converse r) r'))
+
+let%test_unit "monotonicity: if a.before b, shrinking b cannot make a.after b" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      if equal (A.relate a b) Before then
+        let b' = {b with lo = b.lo - 1} in
+        let r = A.relate a b' in
+        assert (not (equal r After)))
+
+let%test_unit "same start implies one of {Starts, Equal, Started_by}" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      if a.lo = b.lo then match A.relate a b with
+        | Starts | Equal | Started_by -> ()
+        | _ -> assert false)
+
+let%test_unit "same end implies one of {Finishes, Equal, Finished_by}" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      if a.hi = b.hi then match A.relate a b with
+        | Finishes | Equal | Finished_by -> ()
+        | _ -> assert false)
+
+let%test_unit "symmetry class preserved under endpoint translation" =
+  T.run_exn (module Pair) ~f:(fun (a, b) ->
+      let shift = 5 in
+      let a2 = {lo = a.lo + shift; hi = a.hi + shift} in
+      let b2 = {lo = b.lo + shift; hi = b.hi + shift} in
+      assert (equal (A.relate a b) (A.relate a2 b2)))
+
+let check expect a b =
+  let r = A.relate a b in
+  assert (equal expect r);
+  let r' = A.relate b a in
+  assert (equal (converse expect) r')
+
+let%test_unit "rel: before" = check Before (1--3) (5--7)
+let%test_unit "rel: meets" = check Meets (1--3) (3--8)
+let%test_unit "rel: overlaps" = check Overlaps (1--5) (3--8)
+let%test_unit "rel: finished_by" = check Finished_by (1--10) (4--10)
+let%test_unit "rel: contains" = check Contains (1--10) (3--7)
+let%test_unit "rel: starts" = check Starts (1--3) (1--10)
+let%test_unit "rel: equal" = check Equal (2--7) (2--7)
+let%test_unit "rel: started_by" = check Started_by (1--10) (1--3)
+let%test_unit "rel: during" = check During (4--6) (1--10)
+let%test_unit "rel: finishes" = check Finishes (4--10) (1--10)
+let%test_unit "rel: overlapped_by" = check Overlapped_by (5--10) (1--7)
+let%test_unit "rel: met_by" = check Met_by (10--15) (5--10)
+let%test_unit "rel: after" = check After (10--15) (1--7)


### PR DESCRIPTION
We can split out the golden/process testing into their own local libraries, and also make the "overwrite" logic easier to use.